### PR TITLE
Added namespaces to filter calls to avoid naming conflicts.

### DIFF
--- a/src/controllers/GroupController.php
+++ b/src/controllers/GroupController.php
@@ -26,7 +26,7 @@ class GroupController extends BaseController {
 		$this->groupForm = $groupForm;
 
 		// Establish Filters
-		$this->beforeFilter('inGroup:Admins');
+		$this->beforeFilter('Sentinel\inGroup:Admins');
 	}
 
 	/**

--- a/src/controllers/UserController.php
+++ b/src/controllers/UserController.php
@@ -44,11 +44,11 @@ class UserController extends BaseController {
 		$this->suspendUserForm = $suspendUserForm;
 
 		//Check CSRF token on POST
-		$this->beforeFilter('csrf', array('on' => 'post'));
+		$this->beforeFilter('Sentinel\csrf', array('on' => 'post'));
 
 		// Set up Auth Filters
-		$this->beforeFilter('auth', array('only' => array('change')));
-		$this->beforeFilter('inGroup:Admins', array('only' => array('show', 'index', 'destroy', 'suspend', 'unsuspend', 'ban', 'unban', 'edit', 'update')));
+		$this->beforeFilter('Sentinel\auth', array('only' => array('change')));
+		$this->beforeFilter('Sentinel\inGroup:Admins', array('only' => array('show', 'index', 'destroy', 'suspend', 'unsuspend', 'ban', 'unban', 'edit', 'update')));
 		//array('except' => array('create', 'store', 'activate', 'resend', 'forgot', 'reset')));
 	}
 


### PR DESCRIPTION
Fixes #5.
As it turns out, this is related to new project creation, and not to anything server or php version specific.

Our filters weren't namespaced so there was a naming conflict on the auth, guest, and csrf filters. This change uses the correct namespaces for our filter calls. Using this syntax we can override the build in filters that share the same name.  After this is merged into a release branch, you should be able to just run `composer update`.
