### PR TITLE
Move messages for validation to help with localization

### DIFF
--- a/src/Sentinel/Service/Form/ChangePassword/ChangePasswordFormLaravelValidator.php
+++ b/src/Sentinel/Service/Form/ChangePassword/ChangePasswordFormLaravelValidator.php
@@ -15,17 +15,4 @@ class ChangePasswordFormLaravelValidator extends AbstractLaravelValidator {
         'newPassword_confirmation' => 'required'
 	);
 
-	/**
-	 * Custom Validation Messages
-	 *
-	 * @var Array 
-	 */
-	protected $messages = array(
-		//'email.required' => 'An email address is required.'
-		'oldPassword.required' => 'You must enter your old password.',
-		'oldPassword.min' => 'Your old password must be at least 6 characters long.',
-		'newPassword.required' => 'You must enter a new password.',
-		'newPassword.min' => 'Your new password must be at least 6 characters long.',
-		'newPassword_confirmation.required' => 'You must confirm your new password.'
-	);
 }

--- a/src/Sentinel/Service/Form/ForgotPassword/ForgotPasswordFormLaravelValidator.php
+++ b/src/Sentinel/Service/Form/ForgotPassword/ForgotPasswordFormLaravelValidator.php
@@ -13,12 +13,4 @@ class ForgotPasswordFormLaravelValidator extends AbstractLaravelValidator {
 		'email' => 'required|min:4|max:32|email',
 	);
 
-	/**
-	 * Custom Validation Messages
-	 *
-	 * @var Array 
-	 */
-	protected $messages = array(
-		//'email.required' => 'An email address is required.'
-	);
 }

--- a/src/Sentinel/Service/Form/Group/GroupFormLaravelValidator.php
+++ b/src/Sentinel/Service/Form/Group/GroupFormLaravelValidator.php
@@ -13,12 +13,4 @@ class GroupFormLaravelValidator extends AbstractLaravelValidator {
 		'name' => 'required|min:4'
 	);
 
-	/**
-	 * Custom Validation Messages
-	 *
-	 * @var Array 
-	 */
-	protected $messages = array(
-		//'email.required' => 'An email address is required.'
-	);
 }

--- a/src/Sentinel/Service/Form/Login/LoginFormLaravelValidator.php
+++ b/src/Sentinel/Service/Form/Login/LoginFormLaravelValidator.php
@@ -14,12 +14,4 @@ class LoginFormLaravelValidator extends AbstractLaravelValidator {
 		'password' => 'required|min:6'
 	);
 
-	/**
-	 * Custom Validation Messages
-	 *
-	 * @var Array 
-	 */
-	protected $messages = array(
-		//'email.required' => 'An email address is required.'
-	);
 }

--- a/src/Sentinel/Service/Form/Register/RegisterFormLaravelValidator.php
+++ b/src/Sentinel/Service/Form/Register/RegisterFormLaravelValidator.php
@@ -15,12 +15,4 @@ class RegisterFormLaravelValidator extends AbstractLaravelValidator {
 		'password_confirmation' => 'required'
 	);
 
-	/**
-	 * Custom Validation Messages
-	 *
-	 * @var Array 
-	 */
-	protected $messages = array(
-		//'email.required' => 'An email address is required.'
-	);
 }

--- a/src/Sentinel/Service/Form/ResendActivation/ResendActivationFormLaravelValidator.php
+++ b/src/Sentinel/Service/Form/ResendActivation/ResendActivationFormLaravelValidator.php
@@ -13,12 +13,4 @@ class ResendActivationFormLaravelValidator extends AbstractLaravelValidator {
 		'email' => 'required|min:4|max:32|email',
 	);
 
-	/**
-	 * Custom Validation Messages
-	 *
-	 * @var Array 
-	 */
-	protected $messages = array(
-		//'email.required' => 'An email address is required.'
-	);
 }

--- a/src/Sentinel/Service/Form/SuspendUser/SuspendUserFormLaravelValidator.php
+++ b/src/Sentinel/Service/Form/SuspendUser/SuspendUserFormLaravelValidator.php
@@ -13,13 +13,4 @@ class SuspendUserFormLaravelValidator extends AbstractLaravelValidator {
 		'minutes' => 'required|numeric',
 	);
 
-	/**
-	 * Custom Validation Messages
-	 *
-	 * @var Array 
-	 */
-	protected $messages = array(
-		'minutes.numeric' => 'Minutes must be a number',
-		'minutes.required' => 'You must specify suspension length in minutes'
-	);
 }

--- a/src/Sentinel/Service/Form/User/UserFormLaravelValidator.php
+++ b/src/Sentinel/Service/Form/User/UserFormLaravelValidator.php
@@ -14,12 +14,4 @@ class UserFormLaravelValidator extends AbstractLaravelValidator {
         'lastName' => 'alpha',
 	);
 
-	/**
-	 * Custom Validation Messages
-	 *
-	 * @var Array 
-	 */
-	protected $messages = array(
-		//'email.required' => 'An email address is required.'
-	);
 }

--- a/src/lang/en/validation.php
+++ b/src/lang/en/validation.php
@@ -74,7 +74,23 @@ return array(
 	|
 	*/
 
-	'custom' => array(),
+	'custom' => array(
+        'oldPassword' => array(
+            'required' => 'You must enter your old password.',
+            'min' => 'Your old password must be at least 6 characters long.',
+        ),
+        'newPassword' => array(
+            'required' => 'You must enter a new password.',
+            'min' => 'Your new password must be at least 6 characters long.',
+        ),
+        'newPassword_confirmation' => array(
+            'required' => 'You must confirm your new password.',
+        ),
+        'minutes' => array(
+            'numeric' => 'Minutes must be a number',
+            'required' => 'You must specify suspension length in minutes',
+        ),
+    ),
 
 	/*
 	|--------------------------------------------------------------------------


### PR DESCRIPTION
Fixes issue #19.
Moved messages from Validation classes to EN language file.
Removed $message variable from extended classes.
