### PR TITLE
Move all views to a view configuration file

### DIFF
--- a/src/Sentinel/Mailers/UserMailer.php
+++ b/src/Sentinel/Mailers/UserMailer.php
@@ -27,7 +27,7 @@ class UserMailer extends Mailer {
 	public function welcome($email, $userId, $activationCode)
 	{
 		$subject = Config::get('Sentinel::config.welcome');
-		$view = 'Sentinel::emails.welcome';
+		$view = Config::get('Sentinel::views.emails.welcome');
 		$data['userId'] = $userId;
 		$data['activationCode'] = $activationCode;
 		$data['email'] = $email;
@@ -45,7 +45,7 @@ class UserMailer extends Mailer {
 	public function forgotPassword($email, $userId, $resetCode)
 	{
 		$subject = Config::get('Sentinel::config.reset_password');
-		$view = 'Sentinel::emails.reset';
+		$view = Config::get('Sentinel::views.emails.reset_password');
 		$data['userId'] = $userId;
 		$data['resetCode'] = $resetCode;
 		$data['email'] = $email;
@@ -63,7 +63,7 @@ class UserMailer extends Mailer {
 	public function newPassword($email, $newPassword)
 	{
 		$subject = Config::get('Sentinel::config.new_password');
-		$view = 'Sentinel::emails.newpassword';
+		$view = Config::get('Sentinel::views.emails.new_password');
 		$data['newPassword'] = $newPassword;
 		$data['email'] = $email;
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -53,20 +53,6 @@ return array(
 
 	/*
 	|--------------------------------------------------------------------------
-	| Layout
-	|--------------------------------------------------------------------------
-	|
-	| By default, the views provided by the package will extend their own 
-	| default view (views/layouts/default.blade.php), even after they have been
-	| published.  This option allows you to extend a custom view instead. 
-	| 
-	*/
-
-	'layout' => 'Sentinel::layouts.default',
-
-
-	/*
-	|--------------------------------------------------------------------------
 	| Registration
 	|--------------------------------------------------------------------------
 	|

--- a/src/config/views.php
+++ b/src/config/views.php
@@ -1,0 +1,65 @@
+<?php
+
+return array(
+
+	/*
+	|--------------------------------------------------------------------------
+	| Default Views
+	|--------------------------------------------------------------------------
+	|
+	*/
+
+	'emails' => array(
+
+		'welcome' 			=> 'sentinel::emails.welcome',
+
+		'password_reset'	=> 'sentinel::emails.reset',
+
+		'new_password'		=> 'sentinel::emails.newpassword',
+
+		),
+
+	'groups' => array(
+
+		'create'	=> 'sentinel::groups.create',
+
+		'edit'		=> 'sentinel::groups.edit',
+
+		'index'		=> 'sentinel::groups.index',
+
+		'show'		=> 'sentinel::groups.show',
+
+		),
+
+	'sessions' => array(
+
+		'login'	=> 'sentinel::sessions.login',
+
+		),
+
+	'users' => array(
+
+		'create'	=> 'sentinel::users.create',
+
+		'edit'		=> 'sentinel::users.edit',
+
+		'forgot'	=> 'sentinel::users.forgot',
+
+		'index'		=> 'sentinel::users.index',
+
+		'resend'	=> 'sentinel::users.resend',
+
+		'show'		=> 'sentinel::users.show',
+
+		'suspend'	=> 'sentinel::users.suspend',
+
+		),
+
+	'layouts' => array(
+
+		'default'		=> 'sentinel::layouts.default',
+
+		'notifications'	=> 'sentinel::layouts.notifications',
+
+		),
+);

--- a/src/controllers/GroupController.php
+++ b/src/controllers/GroupController.php
@@ -37,7 +37,7 @@ class GroupController extends BaseController {
 	public function index()
 	{
 		$groups = $this->group->all();
-		return View::make('Sentinel::groups.index')->with('groups', $groups);
+		return View::make(Config::get('Sentinel::views.groups.index'))->with('groups', $groups);
 	}
 
 	/**
@@ -48,7 +48,7 @@ class GroupController extends BaseController {
 	public function create()
 	{
 		//Form for creating a new Group
-		return View::make('Sentinel::groups.create');
+		return View::make(Config::get('Sentinel::views.groups.create'));
 	}
 
 	/**
@@ -87,7 +87,7 @@ class GroupController extends BaseController {
 		//Show a group and its permissions. 
 		$group = $this->group->byId($id);
 
-		return View::make('Sentinel::groups.show')->with('group', $group);
+		return View::make(Config::get('Sentinel::views.groups.show'))->with('group', $group);
 	}
 
 	/**
@@ -98,7 +98,7 @@ class GroupController extends BaseController {
 	public function edit($id)
 	{
 		$group = $this->group->byId($id);
-		return View::make('Sentinel::groups.edit')->with('group', $group);
+		return View::make(Config::get('Sentinel::views.groups.edit'))->with('group', $group);
 	}
 
 	/**

--- a/src/controllers/SessionController.php
+++ b/src/controllers/SessionController.php
@@ -27,7 +27,7 @@ class SessionController extends BaseController {
 	 */
 	public function create()
 	{
-		return View::make('Sentinel::sessions.login');
+		return View::make(Config::get('Sentinel::views.sessions.login'));
 	}
 
 	/**

--- a/src/controllers/UserController.php
+++ b/src/controllers/UserController.php
@@ -62,7 +62,7 @@ class UserController extends BaseController {
 	{
         $users = $this->user->all();
       
-        return View::make('Sentinel::users.index')->with('users', $users);
+        return View::make(Config::get('Sentinel::views.users.index'))->with('users', $users);
 	}
 
 	/**
@@ -76,11 +76,11 @@ class UserController extends BaseController {
 
         if (!$registration)
         {   
-            Session::flash('error', trans('Sentinel::users.inactive_reg'));
+            Session::flash('error', trans('Sentinel::views.users.inactive_reg'));
             return Redirect::route('home');
         }
 
-        return View::make('Sentinel::users.create');
+        return View::make(Config::get('Sentinel::views.users.create'));
     }
 
     /**
@@ -90,7 +90,7 @@ class UserController extends BaseController {
 	 */
 	public function create()
 	{
-        return View::make('Sentinel::users.create');
+        return View::make(Config::get('Sentinel::views.users.create'));
 	}
 
 	/**
@@ -140,7 +140,7 @@ class UserController extends BaseController {
             // @codeCoverageIgnoreEnd
         }
 
-        return View::make('Sentinel::users.show')->with('user', $user);
+        return View::make(Config::get('Sentinel::views.users.show'))->with('user', $user);
 	}
 
 	/**
@@ -167,7 +167,7 @@ class UserController extends BaseController {
         }
         $allGroups = $this->group->all();
 
-        return View::make('Sentinel::users.edit')->with('user', $user)->with('userGroups', $userGroups)->with('allGroups', $allGroups);
+        return View::make(Config::get('Sentinel::views.users.edit'))->with('user', $user)->with('userGroups', $userGroups)->with('allGroups', $allGroups);
 	}
 
 	/**

--- a/src/routes.php
+++ b/src/routes.php
@@ -32,19 +32,19 @@ Route::get( $register , array('as' => 'Sentinel\register', 'uses' => 'Sentinel\U
 Route::get( $users . '/{id}/activate/{code}', 'Sentinel\UserController@activate');
 Route::get( $resend , array('as' => 'Sentinel\resendActivationForm', function()
 {
-	return View::make('Sentinel::users.resend');
+	return View::make(Config::get('Sentinel::views.users.resend'));
 }));
 Route::post( $resend , 'Sentinel\UserController@resend');
 Route::get( $forgot , array('as' => 'Sentinel\forgotPasswordForm', function()
 {
-	return View::make('Sentinel::users.forgot');
+	return View::make(Config::get('Sentinel::views.users.forgot'));
 }));
 Route::post( $forgot , 'Sentinel\UserController@forgot');
 Route::post( $users . '/{id}/change', 'Sentinel\UserController@change');
 Route::get( $users . '/{id}/reset/{code}', 'Sentinel\UserController@reset');
 Route::get( $users . '/{id}/suspend', array('as' => 'Sentinel\suspendUserForm', function($id)
 {
-	return View::make('Sentinel::users.suspend')->with('id', $id);
+	return View::make(Config::get('Sentinel::views.users.suspend'))->with('id', $id);
 }));
 Route::post( $users . '/{id}/suspend', 'Sentinel\UserController@suspend');
 Route::get( $users . '/{id}/unsuspend', 'Sentinel\UserController@unsuspend');

--- a/src/views/groups/create.blade.php
+++ b/src/views/groups/create.blade.php
@@ -1,4 +1,4 @@
-@extends(Config::get('Sentinel::config.layout'))
+@extends(Config::get('Sentinel::views.layouts.default'))
 
 {{-- Web site Title --}}
 @section('title')

--- a/src/views/groups/edit.blade.php
+++ b/src/views/groups/edit.blade.php
@@ -1,4 +1,4 @@
-@extends(Config::get('Sentinel::config.layout'))
+@extends(Config::get('Sentinel::views.layouts.default'))
 
 {{-- Web site Title --}}
 @section('title')

--- a/src/views/groups/index.blade.php
+++ b/src/views/groups/index.blade.php
@@ -1,4 +1,4 @@
-@extends(Config::get('Sentinel::config.layout'))
+@extends(Config::get('Sentinel::views.layouts.default'))
 
 {{-- Web site Title --}}
 @section('title')

--- a/src/views/groups/show.blade.php
+++ b/src/views/groups/show.blade.php
@@ -1,4 +1,4 @@
-@extends(Config::get('Sentinel::config.layout'))
+@extends(Config::get('Sentinel::views.layouts.default'))
 
 {{-- Web site Title --}}
 @section('title')

--- a/src/views/layouts/default.blade.php
+++ b/src/views/layouts/default.blade.php
@@ -71,7 +71,7 @@
 		<!-- Container -->
 		<div class="container">
 			<!-- Notifications -->
-			@include('Sentinel::layouts/notifications')
+			@include(Config::get('Sentinel::layouts/notifications'))
 			<!-- ./ notifications -->
 
 			<!-- Content -->

--- a/src/views/sessions/login.blade.php
+++ b/src/views/sessions/login.blade.php
@@ -1,4 +1,4 @@
-@extends(Config::get('Sentinel::config.layout'))
+@extends(Config::get('Sentinel::views.layouts.default'))
 
 {{-- Web site Title --}}
 @section('title')

--- a/src/views/users/create.blade.php
+++ b/src/views/users/create.blade.php
@@ -1,4 +1,4 @@
-@extends(Config::get('Sentinel::config.layout'))
+@extends(Config::get('Sentinel::views.layouts.default'))
 
 {{-- Web site Title --}}
 @section('title')

--- a/src/views/users/edit.blade.php
+++ b/src/views/users/edit.blade.php
@@ -1,4 +1,4 @@
-@extends(Config::get('Sentinel::config.layout'))
+@extends(Config::get('Sentinel::views.layouts.default'))
 
 {{-- Web site Title --}}
 @section('title')

--- a/src/views/users/forgot.blade.php
+++ b/src/views/users/forgot.blade.php
@@ -1,4 +1,4 @@
-@extends(Config::get('Sentinel::config.layout'))
+@extends(Config::get('Sentinel::views.layouts.default'))
 
 {{-- Web site Title --}}
 @section('title')

--- a/src/views/users/index.blade.php
+++ b/src/views/users/index.blade.php
@@ -1,4 +1,4 @@
-@extends(Config::get('Sentinel::config.layout'))
+@extends(Config::get('Sentinel::views.layouts.default'))
 
 {{-- Web site Title --}}
 @section('title')

--- a/src/views/users/resend.blade.php
+++ b/src/views/users/resend.blade.php
@@ -1,4 +1,4 @@
-@extends(Config::get('Sentinel::config.layout'))
+@extends(Config::get('Sentinel::views.layouts.default'))
 
 {{-- Web site Title --}}
 @section('title')

--- a/src/views/users/show.blade.php
+++ b/src/views/users/show.blade.php
@@ -1,4 +1,4 @@
-@extends(Config::get('Sentinel::config.layout'))
+@extends(Config::get('Sentinel::views.layouts.default'))
 
 {{-- Web site Title --}}
 @section('title')

--- a/src/views/users/suspend.blade.php
+++ b/src/views/users/suspend.blade.php
@@ -1,4 +1,4 @@
-@extends(Config::get('Sentinel::config.layout'))
+@extends(Config::get('Sentinel::views.layouts.default'))
 
 {{-- Web site Title --}}
 @section('title')


### PR DESCRIPTION
Moved all declaration of what view to make to `config/view.php`. This allows users to easily override the view that will be used within the controller. Sentinel's views are provided as defaults so users are not required to change/implement these views.

This isn't tested as I wasn't sure how the best way to change it would be. 
