### PR TITLE
Added a new filter, 'Sentinel\hasAccess'

### DIFF
--- a/src/filters.php
+++ b/src/filters.php
@@ -39,6 +39,29 @@ Route::filter('Sentinel\auth', function()
 	if (!Sentry::check()) return Redirect::guest(Config::get('Sentinel::config.routes.login'));
 });
 
+Route::filter('Sentinel\hasAccess', function($route, $request, $value)
+{
+	if (!Sentry::check()) return Redirect::guest(Config::get('Sentinel::config.routes.login'));
+
+	$userId = Route::input('users');
+
+	try
+	{
+		$user = Sentry::getUser();
+
+		if ( $userId != Session::get('userId') && (! $user->hasAccess($value)) )
+		{
+			Session::flash('error', trans('Sentinel::users.noaccess'));
+			return Redirect::route('home');
+		}
+	}
+	catch (Cartalyst\Sentry\Users\UserNotFoundException $e)
+	{
+		Session::flash('error', trans('Sentinel::users.notfound'));
+		return Redirect::guest(Config::get('Sentinel::config.routes.login'));
+	}
+});
+
 Route::filter('Sentinel\inGroup', function($route, $request, $value)
 {
 	if (!Sentry::check()) return Redirect::guest(Config::get('Sentinel::config.routes.login'));


### PR DESCRIPTION
Noticed they have added to the original filters that you had, at http://laravelsnippets.com/snippets/sentry-route-filters. I went ahead and made it work similar to the modifications that you added to `Sentinel\inGroup`. 

Also, since you can apply multiple filters to any routes, do we really need to repeat this line of code `if (!Sentry::check()) return Redirect::guest(Config::get('Sentinel::config.routes.login'));` in each filter? Instead, when applying filters you could simply use `'Sentinel\auth|Sentinel\hasAccess'`. 
