### PR TITLE
Fix Mail::queue issue

### DIFF
--- a/src/Sentinel/Mailers/Mailer.php
+++ b/src/Sentinel/Mailers/Mailer.php
@@ -1,15 +1,15 @@
 <?php namespace Sentinel\Mailers;
 
-use Mail;
+use Mail, Queue;
 
 abstract class Mailer {
 
 	public function sendTo($email, $subject, $view, $data = array())
 	{
-		Mail::queue($view, $data, function($message) use($email, $subject)
+		Queue::push(Mail::send($view, $data, function($message) use($email, $subject)
 		{
 			$message->to($email)
 					->subject($subject);
-		});
+		}));
 	}
 }


### PR DESCRIPTION
The serializer seems to be at fault here. A suggestion here,  laravel/framework#3734 , was to use `Queue:push` with `Mail::send` to create a more reliable function. Testing on my setup works fine and I don't see a reason it wouldn't work on another setup. 

This should solve [Sentinel issue#38](https://github.com/rydurham/Sentinel/issues/38)
