### PR TITLE
Add option to have a custom 'verification sent'

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -72,7 +72,7 @@ return array(
 
     'post_logout'   => 'home',
 
-    'post_confirmation_sent' => false //Add a view here to make your own 'verification sent!' page.
+    'confirmation_sent_page' => 'home' //Edit this to show your own 'confirmation sent!' page if you like.
 
     /*
     |--------------------------------------------------------------------------

--- a/src/controllers/UserController.php
+++ b/src/controllers/UserController.php
@@ -287,7 +287,7 @@ class UserController extends BaseController {
         {
             // Success!
             Session::flash('success', $result['message']);
-            return Redirect::route(isset(Config::get('Sentinel::config.post_confirmation_sent')) ? Config::get('Sentinel::config.post_confirmation_sent') : 'home');
+            return Redirect::route(Config::get('Sentinel::config.confirmation_sent_page'));
         }
         else
         {


### PR DESCRIPTION
Instead of just kicking the user back to the homepage after the
verification email has been sent. Fixes unclear behavior and has the
potential to increase usability. (Sorry for spacing changes, look at lines 75 and 104)
