### PR TITLE
Fix column not found error

### DIFF
--- a/src/Sentinel/Service/Form/User/UserForm.php
+++ b/src/Sentinel/Service/Form/User/UserForm.php
@@ -94,7 +94,7 @@ class UserForm {
 			$this->validator->addRules($this->config->get('Sentinel::config.additional_user_fields'));
 		}
 
-		return $this->validator->with($input)->updateUnique('username', 'username', $input['id'])->passes();
+		return $this->validator->with($input)->updateUnique('username', $input['id'], 'id')->passes();
 		
 	}
 


### PR DESCRIPTION
With the original line I get a column not found error when a user attempts to update their username:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column '4' in 'where clause' (SQL: select count(*) as aggregate from `users` where `username` = JoeBloggs and `4` <> username)
```

This fixes the bug.