### PR TITLE
Update SentinelPublishCommand.php

### DIFF
--- a/src/Sentinel/Commands/SentinelPublishCommand.php
+++ b/src/Sentinel/Commands/SentinelPublishCommand.php
@@ -110,7 +110,8 @@ class SentinelPublishCommand extends Command {
         $this->publishSentryConfig();
 
         // Publish the Mitch/Hashids config files
-        $this->publishHashidsConfig();
+        //Commented out until package gets updated
+        //$this->publishHashidsConfig();
 
         // Publish the theme views
         $this->publishViews($theme);


### PR DESCRIPTION
Since the mitch/hashids isn't there, the publish command chokes on you trying to publish an imaginary config.  I just commented out the caller until your'e ready. After this, the publish command works fine.