### PR TITLE
Fix disappearing profile link title

### DIFF
--- a/src/views/blank/layouts/default.blade.php
+++ b/src/views/blank/layouts/default.blade.php
@@ -36,7 +36,7 @@
 						<li {!! (Request::is('groups*') ? 'class="active"' : '') !!}><a href="{{ URL::to('/groups') }}">Groups</a></li>
 					@endif
 		            @if (Sentry::check())
-    				<li {!! (Request::is('profile') ? 'class="active"' : '') !!}><a href="{{ route('sentinel.profile.show') }}">{{ Session::get('email') }}</a></li>
+    				<li {!! (Request::is('profile') ? 'class="active"' : '') !!}><a href="{{ route('sentinel.profile.show') }}">{{ Sentry::getUser()->email }}</a></li>
     				<li><a href="{{ route('sentinel.logout') }}">Logout</a></li>
     				@else
     				<li {!! (Request::is('login') ? 'class="active"' : '') !!}><a href="{{ route('sentinel.login') }}">Login</a></li>

--- a/src/views/bootstrap/layouts/default.blade.php
+++ b/src/views/bootstrap/layouts/default.blade.php
@@ -57,7 +57,7 @@
 	          </ul>
 	          <ul class="nav navbar-nav navbar-right">
 	            @if (Sentry::check())
-				<li {!! (Request::is('profile') ? 'class="active"' : '') !!}><a href="{{ route('sentinel.profile.show') }}">{{ Session::get('email') }}</a>
+				<li {!! (Request::is('profile') ? 'class="active"' : '') !!}><a href="{{ route('sentinel.profile.show') }}">{{ Sentry::getUser()->email }}</a>
 				</li>
 				<li>
 					<a href="{{ route('sentinel.logout') }}">Logout</a>

--- a/src/views/foundation/layouts/default.blade.php
+++ b/src/views/foundation/layouts/default.blade.php
@@ -32,7 +32,7 @@
 			<ul class="right">
 				 @if (Sentry::check())
 					<li {!! (Request::is('profile') ? 'class="active"' : '') !!}>
-						<a href="{{ route('sentinel.profile.show') }}">{{ Session::get('email') }}</a>
+						<a href="{{ route('sentinel.profile.show') }}">{{ Sentry::getUser()->email }}</a>
 					</li>
 					<li>
 						<a href="{{ route('sentinel.logout') }}">Logout</a>

--- a/src/views/gumby/layouts/default.blade.php
+++ b/src/views/gumby/layouts/default.blade.php
@@ -40,7 +40,7 @@
        						<li {!! (Request::is('users*') ? 'class="active"' : '') !!}><a href="{{ action('\\Sentinel\Controllers\UserController@index') }}">Users</a></li>
        						<li {!! (Request::is('groups*') ? 'class="active"' : '') !!}><a href="{{ action('\\Sentinel\Controllers\GroupController@index') }}">Groups</a></li>
        					@endif
-       					<li {!! (Request::is('profile') ? 'class="active"' : '') !!}><a href="{{ route('sentinel.profile.show') }}">{{ Session::get('email') }}</a></li>
+       					<li {!! (Request::is('profile') ? 'class="active"' : '') !!}><a href="{{ route('sentinel.profile.show') }}">{{ Sentry::getUser()->email }}</a></li>
        					<li><a href="{{ route('sentinel.logout') }}">Logout</a></li>
        				@endif 
 		        </ul>

--- a/src/views/materialize/layouts/default.blade.php
+++ b/src/views/materialize/layouts/default.blade.php
@@ -21,7 +21,7 @@
                     @endif
                     @if (Sentry::check())
                         <li {!! (Request::is('profile') ? 'class="active"' : '') !!}>
-                            <a href="{{ route('sentinel.profile.show') }}">{{ Session::get('email') }}</a>
+                            <a href="{{ route('sentinel.profile.show') }}">{{ Sentry::getUser()->email }}</a>
                         </li>
                         <li><a href="{{ route('sentinel.logout') }}">Logout</a></li>
                     @else


### PR DESCRIPTION
Hi!
I noticed that after several hours of inactivity (~half a day or so) the profile link title (user email) becomes empty for logged in user. I tracked it down to the use of email stored in session, which I think is not correct.