### PR TITLE
Don't use session storage to store current user data

### DIFF
--- a/src/Sentinel/Listeners/UserEventListener.php
+++ b/src/Sentinel/Listeners/UserEventListener.php
@@ -2,15 +2,13 @@
 
 namespace Sentinel\Listeners;
 
-use Illuminate\Session\Store;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Contracts\Config\Repository;
 
 class UserEventListener
 {
-    public function __construct(Store $session, Repository $config)
+    public function __construct(Repository $config)
     {
-        $this->session = $session;
         $this->config = $config;
     }
 
@@ -34,8 +32,6 @@ class UserEventListener
      */
     public function onUserLogin($user)
     {
-        $this->session->put('userId', $user->id);
-        $this->session->put('email', $user->email);
     }
 
     /**
@@ -43,7 +39,6 @@ class UserEventListener
      */
     public function onUserLogout()
     {
-        $this->session->flush();
     }
 
     /**

--- a/src/controllers/ProfileController.php
+++ b/src/controllers/ProfileController.php
@@ -45,8 +45,8 @@ class ProfileController extends BaseController
      */
     public function show()
     {
-        // Get the user
-        $user = $this->userRepository->retrieveById(Session::get('userId'));
+        // Grab the current user
+        $user = $this->userRepository->getUser();
 
         return $this->viewFinder('Sentinel::users.show', ['user' => $user]);
     }
@@ -59,8 +59,8 @@ class ProfileController extends BaseController
      */
     public function edit()
     {
-        // Get the user
-        $user = $this->userRepository->retrieveById(Session::get('userId'));
+        // Grab the current user
+        $user = $this->userRepository->getUser();
 
         // Get all available groups
         $groups = $this->groupRepository->all();
@@ -81,7 +81,7 @@ class ProfileController extends BaseController
     {
         // Gather Input
         $data       = Input::all();
-        $data['id'] = Session::get('userId');
+        $data['id'] = $this->userRepository->getUser()->id;
 
         // Attempt to update the user
         $result = $this->userRepository->update($data);
@@ -97,12 +97,12 @@ class ProfileController extends BaseController
      */
     public function changePassword(ChangePasswordRequest $request)
     {
-        // Gather input
-        $data       = Input::all();
-        $data['id'] = Session::get('userId');
-
         // Grab the current user
         $user = $this->userRepository->getUser();
+
+        // Gather input
+        $data       = Input::all();
+        $data['id'] = $user->id;
 
         // Change the User's password
         $result = ($user->hasAccess('admin') ? $this->userRepository->changePasswordWithoutCheck($data) : $this->userRepository->changePassword($data));


### PR DESCRIPTION
Related to PR #178
The session store may be cleared at any time, so it's better not to store important data there.
And since the current user data is available through the User Repository, there is no point in storing it in one more place anyway.