### PR TITLE
Add login view customization possibility through Sentinel config file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "rydurham/sentinel",
+    "name": "bachmay/sentinel",
     "description": "An implementation of the Sentry User Manager for Laravel.",
     "keywords": ["laravel", "sentry", "auth"],
     "license": "BSD-3-Clause",

--- a/src/config/sentinel.php
+++ b/src/config/sentinel.php
@@ -157,7 +157,8 @@ return [
     */
 
     'view' => [
-        'session_login' => 'Sentinel::sessions.login'
+        'session_login' => 'Sentinel::sessions.login',
+        'user_register' => 'Sentinel::users.register'
     ],
 
     /*

--- a/src/config/sentinel.php
+++ b/src/config/sentinel.php
@@ -146,6 +146,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | View selection
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for custom views, such as login for session creation,
+    | since this option is not available through the routing configurations
+    | above. If you will use a custom view, this points directly to the default
+    | views folder in your installation.
+    |
+    */
+
+    'view' => [
+        'session_login' => 'Sentinel::sessions.login'
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Guest Middleware Redirection
     |--------------------------------------------------------------------------
     |

--- a/src/controllers/RegistrationController.php
+++ b/src/controllers/RegistrationController.php
@@ -61,7 +61,7 @@ class RegistrationController extends BaseController
         }
 
         // All clear - show the registration form.
-        return $this->viewFinder('Sentinel::users.register');
+        return $this->viewFinder(config('sentinel.view.user_register'));
     }
 
     /**

--- a/src/controllers/RegistrationController.php
+++ b/src/controllers/RegistrationController.php
@@ -61,7 +61,7 @@ class RegistrationController extends BaseController
         }
 
         // All clear - show the registration form.
-        return $this->viewFinder(config('sentinel.view.user_register'));
+        return $this->viewFinder(config('sentinel.view.user_register', 'Sentinel::users.register'));
     }
 
     /**

--- a/src/controllers/SessionController.php
+++ b/src/controllers/SessionController.php
@@ -43,7 +43,7 @@ class SessionController extends BaseController
         }
 
         // No - they are not signed in.  Show the login form.
-        return $this->viewFinder(config('sentinel.view.session_login'));
+        return $this->viewFinder(config('sentinel.view.session_login', 'Sentinel::sessions.login'));
     }
 
     /**

--- a/src/controllers/SessionController.php
+++ b/src/controllers/SessionController.php
@@ -43,7 +43,7 @@ class SessionController extends BaseController
         }
 
         // No - they are not signed in.  Show the login form.
-        return $this->viewFinder('Sentinel::sessions.login');
+        return $this->viewFinder(config('sentinel.view.session_login'));
     }
 
     /**


### PR DESCRIPTION
This was added for situations where the you want to use whatever Sentinel is providing, but you want to modify the login template. There is no easy way to do it right now without getting too technical.

This update brings up the possibility for the developer to choose the view that will be displayed instead of the original Sentinel login view, just by a simple line in the config file.