### PR TITLE
[UPDATE] User activation flow updated.

### DIFF
--- a/src/Sentinel/Repositories/User/SentryUserRepository.php
+++ b/src/Sentinel/Repositories/User/SentryUserRepository.php
@@ -270,10 +270,12 @@ class SentryUserRepository implements SentinelUserRepositoryInterface, UserProvi
             // The user is already activated
             return new FailureResponse(trans('Sentinel::users.alreadyactive'), ['user' => $user]);
         } catch (UserNotFoundException $e) {
-            // The user is trying to "reactivate" an account that doesn't exist.
-            $message = trans('Sentinel::users.notfound');
+            // The user is trying to "reactivate" an account that doesn't exist.  This could be
+            // a vector for determining valid existing accounts, so we will send a vague
+            // response without actually sending a new activation email.
+            $message = trans('Sentinel::users.pendingactivation');
 
-            return new FailureResponse($message, []);
+            return new SuccessResponse($message, []);
         }
     }
 

--- a/src/Sentinel/Repositories/User/SentryUserRepository.php
+++ b/src/Sentinel/Repositories/User/SentryUserRepository.php
@@ -252,12 +252,10 @@ class SentryUserRepository implements SentinelUserRepositoryInterface, UserProvi
             // The user is already activated
             return new FailureResponse(trans('Sentinel::users.alreadyactive'), ['user' => $user]);
         } catch (UserNotFoundException $e) {
-            // The user is trying to "reactivate" an account that doesn't exist.  This could be
-            // a vector for determining valid existing accounts, so we will send a vague
-            // response without actually sending a new activation email.
-            $message = trans('Sentinel::users.emailconfirm');
+            // The user is trying to "reactivate" an account that doesn't exist.
+            $message = trans('Sentinel::users.notfound');
 
-            return new SuccessResponse($message, []);
+            return new FailureResponse($message, []);
         }
     }
 

--- a/src/Sentinel/Repositories/User/SentryUserRepository.php
+++ b/src/Sentinel/Repositories/User/SentryUserRepository.php
@@ -111,8 +111,26 @@ class SentryUserRepository implements SentinelUserRepositoryInterface, UserProvi
             // Return a response
             return new SuccessResponse($message, $payload);
         } catch (UserExistsException $e) {
-            $message = trans('Sentinel::users.exists');
+            // If the User is already registered but hasn't yet completed the activation
+            // process resend the activation email and show appropriate message.
+            
+            if( $this->config->get('sentinel.require_activation', true) ) {
 
+                //Attempt to find the user.
+                $user = $this->sentry->getUserProvider()->findByLogin(e($data['email']));
+
+                // If the user is not currently activated resend the activation email
+                if (!$user->isActivated()) {
+                    $this->dispatcher->fire('sentinel.user.resend', [
+                        'user' => $user,
+                        'activated' => $user->activated,
+                    ]);
+
+                    return new FailureResponse(trans('Sentinel::users.pendingactivation'), ['user' => $user]);
+                }                
+            }
+
+            $message = trans('Sentinel::users.exists');
             return new ExceptionResponse($message);
         }
     }

--- a/src/Sentinel/Repositories/User/SentryUserRepository.php
+++ b/src/Sentinel/Repositories/User/SentryUserRepository.php
@@ -114,7 +114,7 @@ class SentryUserRepository implements SentinelUserRepositoryInterface, UserProvi
             // If the User is already registered but hasn't yet completed the activation
             // process resend the activation email and show appropriate message.
             
-            if( $this->config->get('sentinel.require_activation', true) ) {
+            if ($this->config->get('sentinel.require_activation', true)) {
 
                 //Attempt to find the user.
                 $user = $this->sentry->getUserProvider()->findByLogin(e($data['email']));
@@ -127,7 +127,7 @@ class SentryUserRepository implements SentinelUserRepositoryInterface, UserProvi
                     ]);
 
                     return new FailureResponse(trans('Sentinel::users.pendingactivation'), ['user' => $user]);
-                }                
+                }
             }
 
             $message = trans('Sentinel::users.exists');

--- a/src/lang/en/users.php
+++ b/src/lang/en/users.php
@@ -34,7 +34,7 @@ return array(
 
     'alreadyactive'    =>    "That account has already been activated.",
 
-    'pendingactivation' => "You haven’t activated your account yet. Please check your email and activate your account.",
+    'pendingactivation' => "If an account for this email is found, you will receive the activation email in the next few minutes.",
 
     'emailconfirm'    =>    "Check your email for the confirmation link.",
 

--- a/src/lang/en/users.php
+++ b/src/lang/en/users.php
@@ -34,6 +34,8 @@ return array(
 
     'alreadyactive'    =>    "That account has already been activated.",
 
+    'pendingactivation' => "You haven’t activated your account yet. Please check your email and activate your account.",
+
     'emailconfirm'    =>    "Check your email for the confirmation link.",
 
     'emailinfo'        =>    "Check your email for instructions.",


### PR DESCRIPTION
If User requests activation email for an invalid account, send a failure response with User not found message. 

FIXES #208 