### PR TITLE
Add Laravel 8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.3
   - 7.4
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,15 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
-        "illuminate/support": "^7.0",
-        "illuminate/contracts": "^7.0",
+        "php": "^7.3",
+        "ext-bcmath": "*",
+        "illuminate/support": "^8.0",
+        "illuminate/contracts": "^8.0",
         "cartalyst/sentry": "^2.0",
-        "vinkla/hashids": "^8.0"
+        "vinkla/hashids": "^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0",
+        "orchestra/testbench": "^6.0",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^8.5"
     },

--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,9 @@ __Releases__ There are several versions of this package, each intended for diffe
 
 | Laravel Version  | Sentinel Version  | Packagist Branch |
 |---|---|---|
-| 5.8.*  | 2.10.*  | ```"rydurham/sentinel": "~2.10"``` |
 | 6.0.*  | 3.0.*  | ```"rydurham/sentinel": "~3.0"``` |
-| 7.0.*  | 4.0.*  | ```"rydurham/sentinel": "~3.0"``` |
+| 7.0.*  | 4.0.*  | ```"rydurham/sentinel": "~4.0"``` |
+| 7.0.*  | 4.0.*  | ```"rydurham/sentinel": "~5.0"``` |
 
 ### Laravel 5 Instructions
 **Install the Package Via Composer:**


### PR DESCRIPTION
This PR adds support for Laravel 8, and also notes the ext-bcmath dependency to the composer.json
file.
